### PR TITLE
Enhancement/api promissory note

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
+++ b/fineract-core/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
@@ -3793,4 +3793,13 @@ public class CommandWrapperBuilder {
         this.href = "/v1/loans/external-id/" + loanExternalId + "/interest-pauses/" + variationId;
         return this;
     }
+
+    public CommandWrapperBuilder createPromissoryNote() {
+        this.actionName = "CREATE";
+        this.entityName = "PROMISSORY_NOTE";
+        this.entityId = null;
+        this.href = "/v1/promissorynote";
+        return this;
+    }
+
 }

--- a/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/AbstractPlatformResourceAlreadyBeenAssignedException.java
+++ b/fineract-core/src/main/java/org/apache/fineract/infrastructure/core/exception/AbstractPlatformResourceAlreadyBeenAssignedException.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.core.exception;
+
+/**
+ * A {@link RuntimeException} thrown for cases where a resource has already been allocated.
+ */
+public abstract class AbstractPlatformResourceAlreadyBeenAssignedException extends AbstractPlatformException {
+
+    protected AbstractPlatformResourceAlreadyBeenAssignedException(String globalisationMessageCode, String defaultUserMessage,
+                                                                   Object... defaultUserMessageArgs) {
+        super(globalisationMessageCode, defaultUserMessage, defaultUserMessageArgs);
+    }
+}

--- a/fineract-core/src/main/resources/jpa/core/persistence.xml
+++ b/fineract-core/src/main/resources/jpa/core/persistence.xml
@@ -29,6 +29,9 @@
     <!--  You can find the runtime configuration in the JPAConfig class  -->
     <persistence-unit name="jpa-pu" transaction-type="RESOURCE_LOCAL">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+
+        <!-- Belat module -->
+        <class>com.belat.fineract.portfolio.promissorynote.domain.PromissoryNote</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.weaving" value="static" />

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/api/PromissoryNoteApiResource.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/api/PromissoryNoteApiResource.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.api;
+
+import com.belat.fineract.portfolio.promissorynote.data.PromissoryNoteData;
+import com.belat.fineract.portfolio.promissorynote.service.impl.PromissoryNoteReadPlatformServiceImpl;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.commands.service.CommandWrapperBuilder;
+import org.apache.fineract.commands.service.PortfolioCommandSourceWritePlatformService;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.security.service.PlatformUserRightsContext;
+import org.springframework.stereotype.Component;
+
+@Path("/v1/promissorynote")
+@Component
+@Tag(name = "promissorynote", description = "PromissoryNote")
+@RequiredArgsConstructor
+public class PromissoryNoteApiResource {
+
+    private final PlatformUserRightsContext platformUserRightsContext;
+    private final PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService;
+    private final DefaultToApiJsonSerializer<PromissoryNoteData> apiJsonSerializerService;
+    private final PromissoryNoteReadPlatformServiceImpl noteReadPlatformService;
+
+    @POST
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = PromissoryNoteApiResourceSwagger.PostAddPromissoryNoteRequest.class)))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PromissoryNoteApiResourceSwagger.PostAddPromissoryNoteResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Promissory can not be created") })
+    public String addPromissoryNote(@Parameter(hidden = true) final String apiRequestBodyAsJson) {
+        platformUserRightsContext.isAuthenticated();
+        final CommandWrapper commandRequest = new CommandWrapperBuilder().withJson(apiRequestBodyAsJson).createPromissoryNote().build();
+        CommandProcessingResult result = this.commandsSourceWritePlatformService.logCommandSource(commandRequest);
+        return apiJsonSerializerService.serialize(result);
+    }
+
+    @GET
+    @Produces({ MediaType.APPLICATION_JSON })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PromissoryNoteApiResourceSwagger.PostAddPromissoryNoteRequest.class))) })
+    public String getAllPromissoryNumber() {
+        platformUserRightsContext.isAuthenticated();
+
+        List<PromissoryNoteData> promissoryNotes = noteReadPlatformService.retrieveAll();
+
+        return apiJsonSerializerService.serialize(promissoryNotes);
+    }
+
+    @GET
+    @Path("{promissoryNumber}")
+    @Produces({ MediaType.APPLICATION_JSON })
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PromissoryNoteApiResourceSwagger.PostAddPromissoryNoteRequest.class))) })
+    public String getPromissoryNumber(@PathParam("promissoryNumber") final String promissoryNumber) {
+        platformUserRightsContext.isAuthenticated();
+
+        final PromissoryNoteData promissoryNoteData = noteReadPlatformService.retrieveOneByPromissoryNoteNumber(promissoryNumber);
+        return apiJsonSerializerService.serialize(promissoryNoteData);
+    }
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/api/PromissoryNoteApiResourceSwagger.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/api/PromissoryNoteApiResourceSwagger.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+
+public class PromissoryNoteApiResourceSwagger {
+
+    private PromissoryNoteApiResourceSwagger() {}
+
+    @Schema(description = "PostAddPromissoryNoteRequest")
+    static final class PostAddPromissoryNoteRequest {
+
+        private PostAddPromissoryNoteRequest() {}
+
+        @Schema(example = "1")
+        public String fundSavingsAccountId;
+
+        @Schema(example = "2")
+        public String investorSavingsAccountId;
+
+        @Schema(example = "1000.00")
+        public BigDecimal amount;
+
+        @Schema(example = "1234567890")
+        public String promissoryNoteNumber;
+
+        @Schema(example = "1")
+        public Integer status;
+    }
+
+    @Schema(description = "PostAddPromissoryNoteResponse")
+    static final class PostAddPromissoryNoteResponse {
+
+        private PostAddPromissoryNoteResponse() {}
+
+        @Schema(example = "1")
+        public Long resourceId;
+    }
+
+    @Schema(description = "GetPromissoryNoteResponse")
+    static final class GetPromissoryNoteResponse {
+
+        private GetPromissoryNoteResponse() {}
+
+        @Schema(example = "1")
+        public Long id;
+
+        @Schema(example = "1")
+        public String fundSavingsAccountId;
+
+        @Schema(example = "2")
+        public String investorSavingsAccountId;
+
+        @Schema(example = "1000.00")
+        public BigDecimal amount;
+
+        @Schema(example = "1234567890")
+        public String promissoryNoteNumber;
+
+        @Schema(example = "1")
+        public Integer status;
+    }
+
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/api/PromissoryNoteConstants.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/api/PromissoryNoteConstants.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.api;
+
+public final class PromissoryNoteConstants {
+
+    private PromissoryNoteConstants() {}
+
+    public static final String fundSavingsAccountIdParamName = "fundSavingsAccountId";
+    public static final String investorSavingsAccountIdParamName = "investorSavingsAccountId";
+    public static final String amountParamName = "amount";
+    public static final String currencyCodeParamName = "currencyCode";
+
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/data/PromissoryNoteData.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/data/PromissoryNoteData.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.data;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.apache.fineract.portfolio.savings.data.SavingsAccountData;
+
+@Data
+@AllArgsConstructor
+public class PromissoryNoteData {
+
+    private SavingsAccountData fundSavingsAccount;
+    private SavingsAccountData investorSavingsAccount;
+    private BigDecimal investmentAmount;
+    private String status;
+    private String promissoryNoteNumber;
+    private String currencyCode;
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/domain/PromissoryNote.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/domain/PromissoryNote.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.belat.fineract.portfolio.promissorynote.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.apache.fineract.infrastructure.core.domain.AbstractAuditableWithUTCDateTimeCustom;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccount;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@Table(name = "e_promissory_note")
+public class PromissoryNote extends AbstractAuditableWithUTCDateTimeCustom<Long> {
+
+    @Enumerated(EnumType.ORDINAL)
+    @Column(name = "status_enum", nullable = false)
+    private PromissoryNoteStatus status;
+
+    @ToString.Exclude
+    @OneToOne
+    @JoinColumn(name = "fund_savings_account_id", nullable = false, referencedColumnName = "id")
+    private SavingsAccount fundSavingsAccount;
+
+    @ToString.Exclude
+    @OneToOne
+    @JoinColumn(name = "investor_savings_account_id", nullable = false, referencedColumnName = "id")
+    private SavingsAccount investorSavingsAccount;
+
+    @Column(name = "investment_amount", nullable = false)
+    private BigDecimal investmentAmount;
+
+    @Column(name = "promissory_note_number", length = 20, unique = true, nullable = false)
+    private String promissoryNoteNumber;
+
+    @Column(name = "currency_code", nullable = false)
+    private String currencyCode;
+
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/domain/PromissoryNoteRepository.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/domain/PromissoryNoteRepository.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PromissoryNoteRepository extends JpaRepository<PromissoryNote, Long> {
+
+    @Query("SELECT p FROM PromissoryNote p WHERE p.promissoryNoteNumber = :promissoryNoteNumber")
+    PromissoryNote retrieveOneByPromissoryNoteNumber(@Param("promissoryNoteNumber") String promissoryNoteNumber);
+
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/domain/PromissoryNoteStatus.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/domain/PromissoryNoteStatus.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.domain;
+
+public enum PromissoryNoteStatus {
+
+    ACTIVE(0, "active"), CLOSE(1, "close");
+
+    private final Integer value;
+    private final String code;
+
+    PromissoryNoteStatus(Integer value, String code) {
+        this.value = value;
+        this.code = code;
+    }
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/exception/PromissoryAlreadyBeenAssignedException.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/exception/PromissoryAlreadyBeenAssignedException.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.exception;
+
+import org.apache.fineract.infrastructure.core.exception.AbstractPlatformException;
+
+public class PromissoryAlreadyBeenAssignedException extends AbstractPlatformException {
+
+
+    protected PromissoryAlreadyBeenAssignedException(String globalisationMessageCode, String defaultUserMessage) {
+        super(globalisationMessageCode, defaultUserMessage);
+    }
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/exception/PromissoryNoteNotFoundException.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/exception/PromissoryNoteNotFoundException.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.exception;
+
+import org.apache.fineract.infrastructure.core.exception.AbstractPlatformResourceNotFoundException;
+
+public class PromissoryNoteNotFoundException extends AbstractPlatformResourceNotFoundException {
+
+    public PromissoryNoteNotFoundException(final Long id) {
+        super("error.msg.promissory.id.invalid", "Promissory note with identifier " + id + " does not exist", id);
+    }
+
+    public PromissoryNoteNotFoundException(final String code) {
+        super("error.msg.promissory.code.id.invalid", "Promissory note with code " + code + " does not exist", code);
+    }
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/handler/AddPromissoryNoteCommandHandler.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/handler/AddPromissoryNoteCommandHandler.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.handler;
+
+import com.belat.fineract.portfolio.promissorynote.service.impl.PromissoryNoteWritePlatformServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.apache.fineract.commands.annotation.CommandType;
+import org.apache.fineract.commands.handler.NewCommandSourceHandler;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@CommandType(entity = "PROMISSORY_NOTE", action = "CREATE")
+public class AddPromissoryNoteCommandHandler implements NewCommandSourceHandler {
+
+    private final PromissoryNoteWritePlatformServiceImpl promissoryNoteWritePlatformService;
+
+    @Override
+    public CommandProcessingResult processCommand(JsonCommand command) {
+        return promissoryNoteWritePlatformService.addPromissoryNote(command);
+    }
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/mapper/PromissoryNoteMapper.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/mapper/PromissoryNoteMapper.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.mapper;
+
+import com.belat.fineract.portfolio.promissorynote.data.PromissoryNoteData;
+import com.belat.fineract.portfolio.promissorynote.domain.PromissoryNote;
+import java.util.List;
+import org.apache.fineract.infrastructure.core.config.MapstructMapperConfig;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(config = MapstructMapperConfig.class)
+public interface PromissoryNoteMapper {
+
+    @Mapping(target = "fundSavingsAccount", ignore = true)
+    @Mapping(target = "investorSavingsAccount", ignore = true)
+    PromissoryNoteData map(PromissoryNote source);
+
+    List<PromissoryNoteData> map(List<PromissoryNote> sources);
+
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/service/PromissoryNoteReadPlatformService.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/service/PromissoryNoteReadPlatformService.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.service;
+
+import com.belat.fineract.portfolio.promissorynote.data.PromissoryNoteData;
+import java.util.List;
+
+public interface PromissoryNoteReadPlatformService {
+
+    List<PromissoryNoteData> retrieveAll();
+
+    PromissoryNoteData retrieveOne(Long id);
+
+    PromissoryNoteData retrieveOneByPromissoryNoteNumber(String promissoryNoteNumber);
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/service/PromissoryNoteWritePlatformService.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/service/PromissoryNoteWritePlatformService.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.service;
+
+import com.belat.fineract.portfolio.promissorynote.domain.PromissoryNote;
+import com.google.gson.JsonElement;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+
+public interface PromissoryNoteWritePlatformService {
+
+    PromissoryNote createPromissoryNote(JsonElement element);
+
+    void validatePromissoryNoteRequestBody(final JsonCommand command);
+
+    CommandProcessingResult addPromissoryNote(JsonCommand command);
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/service/impl/PromissoryNoteReadPlatformServiceImpl.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/service/impl/PromissoryNoteReadPlatformServiceImpl.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.service.impl;
+
+import com.belat.fineract.portfolio.promissorynote.data.PromissoryNoteData;
+import com.belat.fineract.portfolio.promissorynote.domain.PromissoryNote;
+import com.belat.fineract.portfolio.promissorynote.domain.PromissoryNoteRepository;
+import com.belat.fineract.portfolio.promissorynote.exception.PromissoryNoteNotFoundException;
+import com.belat.fineract.portfolio.promissorynote.mapper.PromissoryNoteMapper;
+import com.belat.fineract.portfolio.promissorynote.service.PromissoryNoteReadPlatformService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PromissoryNoteReadPlatformServiceImpl implements PromissoryNoteReadPlatformService {
+
+    private final PromissoryNoteRepository promissoryNoteRepository;
+    private final PromissoryNoteMapper promissoryNoteMapper;
+    // private final SavingsAccountReadPlatformServiceImpl savingsAccountReadPlatformService;
+
+    @Override
+    public List<PromissoryNoteData> retrieveAll() {
+        List<PromissoryNote> promissory = promissoryNoteRepository.findAll();
+        return promissoryNoteMapper.map(promissory);
+    }
+
+    @Override
+    public PromissoryNoteData retrieveOne(Long id) {
+        PromissoryNote promissory = promissoryNoteRepository.findById(id).orElseThrow(() -> new PromissoryNoteNotFoundException(id));
+
+        PromissoryNoteData promissoryNoteData = promissoryNoteMapper.map(promissory);
+        return promissoryNoteMapper.map(promissory);
+    }
+
+    @Override
+    public PromissoryNoteData retrieveOneByPromissoryNoteNumber(String promissoryNoteNumber) {
+        PromissoryNote promissory = promissoryNoteRepository.retrieveOneByPromissoryNoteNumber(promissoryNoteNumber);
+        return promissoryNoteMapper.map(promissory);
+    }
+}

--- a/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/service/impl/PromissoryNoteWritePlatformServiceImpl.java
+++ b/fineract-local/src/main/java/com/belat/fineract/portfolio/promissorynote/service/impl/PromissoryNoteWritePlatformServiceImpl.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.belat.fineract.portfolio.promissorynote.service.impl;
+
+import com.belat.fineract.portfolio.promissorynote.api.PromissoryNoteConstants;
+import com.belat.fineract.portfolio.promissorynote.domain.PromissoryNote;
+import com.belat.fineract.portfolio.promissorynote.domain.PromissoryNoteRepository;
+import com.belat.fineract.portfolio.promissorynote.domain.PromissoryNoteStatus;
+import com.belat.fineract.portfolio.promissorynote.exception.PromissoryAlreadyBeenAssignedException;
+import com.belat.fineract.portfolio.promissorynote.service.PromissoryNoteWritePlatformService;
+import com.google.gson.JsonElement;
+import jakarta.transaction.Transactional;
+import java.math.BigDecimal;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
+import org.apache.fineract.infrastructure.core.data.DataValidatorBuilder;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
+import org.apache.fineract.portfolio.savings.domain.SavingsAccountRepository;
+import org.apache.fineract.portfolio.savings.exception.SavingsAccountNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class PromissoryNoteWritePlatformServiceImpl implements PromissoryNoteWritePlatformService {
+
+    private final FromJsonHelper fromApiJsonHelper;
+    private final PromissoryNoteRepository noteRepository;
+    private final SavingsAccountRepository savingsAccountRepository;
+
+    @Override
+    public CommandProcessingResult addPromissoryNote(JsonCommand command) {
+
+        validatePromissoryNoteRequestBody(command);
+        PromissoryNote promissoryNote = createPromissoryNote(fromApiJsonHelper.parse(command.json()));
+        String promissoryNumberFund = promissoryNote.getFundSavingsAccount().getClient().getDisplayName();
+        promissoryNumberFund = promissoryNumberFund.substring(promissoryNumberFund.indexOf("_") + 1);
+        String promissoryNumberInvestor = String.valueOf(promissoryNote.getInvestorSavingsAccount().getClient().getId());
+        promissoryNote.setPromissoryNoteNumber(paddingNumberPromissory(promissoryNumberInvestor, promissoryNumberFund));
+
+        promissoryNote = noteRepository.save(promissoryNote);
+
+        return new CommandProcessingResultBuilder().withCommandId(command.commandId()).withEntityId(promissoryNote.getId()).build();
+    }
+
+    @Override
+    public void validatePromissoryNoteRequestBody(final JsonCommand command) {
+        final String apiRequestBodyAsJson = command.json();
+        final Set<String> requestParameters = new HashSet<>(Arrays.asList(PromissoryNoteConstants.fundSavingsAccountIdParamName,
+                PromissoryNoteConstants.investorSavingsAccountIdParamName, PromissoryNoteConstants.amountParamName));
+
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+        final DataValidatorBuilder baseDataValidator = new DataValidatorBuilder(dataValidationErrors).resource("promissoryNote");
+        final JsonElement json = fromApiJsonHelper.parse(apiRequestBodyAsJson);
+
+        final String fundSavingsAccountId = fromApiJsonHelper.extractStringNamed(PromissoryNoteConstants.fundSavingsAccountIdParamName,
+                json);
+        baseDataValidator.reset().parameter(PromissoryNoteConstants.fundSavingsAccountIdParamName).value(fundSavingsAccountId).notBlank()
+                .notNull();
+
+        final String investorSavingsAccountId = fromApiJsonHelper
+                .extractStringNamed(PromissoryNoteConstants.investorSavingsAccountIdParamName, json);
+        baseDataValidator.reset().parameter(PromissoryNoteConstants.investorSavingsAccountIdParamName).value(investorSavingsAccountId)
+                .notBlank().notNull();
+
+        final String currencyCode = fromApiJsonHelper.extractStringNamed(PromissoryNoteConstants.currencyCodeParamName, json);
+        baseDataValidator.reset().parameter(PromissoryNoteConstants.currencyCodeParamName).value(currencyCode).notBlank().notNull();
+
+        if (!dataValidationErrors.isEmpty()) {
+            throw new PlatformApiDataValidationException("validation.msg.validation.errors.exist", "Validation errors exist.",
+                    dataValidationErrors);
+        }
+    }
+
+    @Override
+    public PromissoryNote createPromissoryNote(JsonElement element) {
+
+        PromissoryNote promissoryNote = new PromissoryNote();
+
+        promissoryNote.setStatus(PromissoryNoteStatus.ACTIVE);
+        promissoryNote.setInvestmentAmount(getAmountFromJson(element));
+        promissoryNote.setFundSavingsAccount(savingsAccountRepository.findById(getFundSavingAccountIdFromJson(element)).orElseThrow(() -> new SavingsAccountNotFoundException(getFundSavingAccountIdFromJson(element))));
+        promissoryNote
+                .setInvestorSavingsAccount(savingsAccountRepository.findById(getInvestorSavingAccountIdFromJson(element)).orElseThrow(() -> new SavingsAccountNotFoundException(getInvestorSavingAccountIdFromJson(element))));
+        promissoryNote.setCurrencyCode(getCurrencyCodeFromJson(element));
+        promissoryNote.setPromissoryNoteNumber(promissoryNote.getFundSavingsAccount().getAccountNumber());
+
+        if (!Objects.equals(promissoryNote.getFundSavingsAccount().getCurrency().getCode(),
+                promissoryNote.getInvestorSavingsAccount().getCurrency().getCode())) {
+            String developerMessage = MessageFormat.format("The currency of the accounts is different code:{0}, code:{1}",
+                    promissoryNote.getFundSavingsAccount().getCurrency().getCode(),
+                    promissoryNote.getInvestorSavingsAccount().getCurrency().getCode());
+            throw new PlatformApiDataValidationException("validation.msg.validation.errors.exist", developerMessage, null);
+        }
+
+        return promissoryNote;
+    }
+
+    private Long getFundSavingAccountIdFromJson(JsonElement json) {
+        return fromApiJsonHelper.extractLongNamed(PromissoryNoteConstants.fundSavingsAccountIdParamName, json);
+    }
+
+    private Long getInvestorSavingAccountIdFromJson(JsonElement json) {
+        return fromApiJsonHelper.extractLongNamed(PromissoryNoteConstants.investorSavingsAccountIdParamName, json);
+    }
+
+    private String getCurrencyCodeFromJson(JsonElement json) {
+        return fromApiJsonHelper.extractStringNamed(PromissoryNoteConstants.currencyCodeParamName, json);
+    }
+
+    private BigDecimal getAmountFromJson(JsonElement json) {
+        final Locale locale = fromApiJsonHelper.extractLocaleParameter(json.getAsJsonObject());
+        return fromApiJsonHelper.extractBigDecimalNamed(PromissoryNoteConstants.amountParamName, json, locale);
+    }
+
+    private String paddingNumberPromissory(String clientId, String numberFund) {
+        int number = 19 - (clientId.length() + numberFund.length());
+        String newNumber = "";
+        for (int i = 0; i < number; i++) {
+            newNumber = newNumber.concat("0");
+        }
+
+        String promissoryNoteNumber = numberFund.concat("_" + newNumber.concat(clientId));
+        validatePromissoryNoteNumber(promissoryNoteNumber);
+        return promissoryNoteNumber;
+    }
+
+    private void validatePromissoryNoteNumber(String number) {
+        PromissoryNote promissoryNote = noteRepository.retrieveOneByPromissoryNoteNumber(number);
+        if (promissoryNote != null) {
+            throw new PlatformApiDataValidationException("error.msg.resource.has.assigned", "The promissory note already exists", number);
+        }
+    }
+}

--- a/fineract-local/src/main/resources/db/changelog/tenant/module/local/module-changelog-master.xml
+++ b/fineract-local/src/main/resources/db/changelog/tenant/module/local/module-changelog-master.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+  <include relativeToChangelogFile="true" file="parts/9001_add_table_promissory_note.xml"/>
+  <include relativeToChangelogFile="true" file="parts/9002_add_permissions_create_promissory_note.xml"/>
+</databaseChangeLog>

--- a/fineract-local/src/main/resources/db/changelog/tenant/module/local/parts/9001_add_table_promissory_note.xml
+++ b/fineract-local/src/main/resources/db/changelog/tenant/module/local/parts/9001_add_table_promissory_note.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="fineract" id="1">
+        <createTable tableName="e_promissory_note">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="status_enum" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="fund_savings_account_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="investor_savings_account_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="investment_amount" type="DECIMAL(19, 6)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="promissory_note_number" type="VARCHAR(20)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="currency_code" type="VARCHAR(20)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_by" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_on_utc" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_modified_by" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_modified_on_utc" type="TIMESTAMP WITH TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="version" type="BIGINT">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet author="fineract" id="2">
+        <addForeignKeyConstraint baseColumnNames="fund_savings_account_id" baseTableName="e_promissory_note"
+                                 constraintName="FK_fund_savings_account" deferrable="false"
+                                 initiallyDeferred="false"
+                                 onDelete="CASCADE" onUpdate="CASCADE" referencedColumnNames="id"
+                                 referencedTableName="m_savings_account" validate="true"/>
+
+        <addForeignKeyConstraint baseColumnNames="investor_savings_account_id" baseTableName="e_promissory_note"
+                                 constraintName="FK_investor_savings_account" deferrable="false"
+                                 initiallyDeferred="false"
+                                 onDelete="SET NULL" onUpdate="CASCADE" referencedColumnNames="id"
+                                 referencedTableName="m_savings_account" validate="true"/>
+    </changeSet>
+
+
+    <changeSet author="fineract" id="3">
+        <createIndex indexName="IDX_fund_savings_account_id" tableName="e_promissory_note">
+            <column name="fund_savings_account_id"/>
+        </createIndex>
+        <createIndex indexName="IDX_investor_savings_account_id" tableName="e_promissory_note">
+            <column name="investor_savings_account_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/fineract-local/src/main/resources/db/changelog/tenant/module/local/parts/9002_add_permissions_create_promissory_note.xml
+++ b/fineract-local/src/main/resources/db/changelog/tenant/module/local/parts/9002_add_permissions_create_promissory_note.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="fineract" id="1">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="m_permission"/>
+                <and>
+                    <columnExists tableName="m_permission" columnName="code"/>
+                    <sqlCheck expectedResult="0">
+                        SELECT COUNT(*) FROM m_permission WHERE code = 'CREATE_PROMISSORY_NOTE'
+                    </sqlCheck>
+                </and>
+            </not>
+        </preConditions>
+        <insert tableName="m_permission">
+            <column name="grouping" value="transaction_savings"/>
+            <column name="code" value="CREATE_PROMISSORY_NOTE"/>
+            <column name="entity_name" value="PROMISSORY_NOTE"/>
+            <column name="action_name" value="CREATE"/>
+            <column name="can_maker_checker" valueBoolean="false"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/fineract-local/src/main/resources/jpa/local/persistence.xml
+++ b/fineract-local/src/main/resources/jpa/local/persistence.xml
@@ -211,6 +211,7 @@
         <class>org.apache.fineract.portfolio.floatingrates.domain.FloatingRatePeriod</class>
         <!-- Fineract Branch module -->
         <class>org.apache.fineract.organisation.thirdparty.domain.ThirdParty</class>
+        <class>com.belat.fineract.portfolio.promissorynote.domain.PromissoryNote</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.weaving" value="static" />

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/boot/FineractWebApplicationConfiguration.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/boot/FineractWebApplicationConfiguration.java
@@ -49,8 +49,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 @EnableWebSecurity
 @EnableConfigurationProperties({ FineractProperties.class, LiquibaseProperties.class })
-@ComponentScan(basePackages = "org.apache.fineract.**")
-@IntegrationComponentScan(basePackages = "org.apache.fineract.**")
+@ComponentScan(basePackages = { "org.apache.fineract.**", "com.belat.fineract.**" })
+@IntegrationComponentScan(basePackages = { "org.apache.fineract.**", "com.belat.fineract.**" })
 @Conditional(FineractWebApplicationCondition.class)
 @Slf4j
 // The class needs to be abstract for some reason, otherwise the tests start to fail...

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/jpa/JPAConfig.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/config/jpa/JPAConfig.java
@@ -57,7 +57,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 @Configuration
 @EnableJpaAuditing
-@EnableJpaRepositories(basePackages = { "org.apache.fineract.**.domain", "org.apache.fineract.**.repository" })
+@EnableJpaRepositories(basePackages = { "org.apache.fineract.**.domain", "org.apache.fineract.**.repository",
+        "com.belat.fineract.**.domain" })
 @EnableConfigurationProperties(JpaProperties.class)
 @Import(JpaAuditingHandlerRegistrar.class)
 public class JPAConfig extends JpaBaseConfiguration {
@@ -97,6 +98,7 @@ public class JPAConfig extends JpaBaseConfiguration {
     protected String[] getPackagesToScan() {
         Set<String> packagesToScan = new HashSet<>();
         packagesToScan.add("org.apache.fineract");
+        packagesToScan.add("com.belat.fineract");
         emFactoryCustomizers.forEach(c -> packagesToScan.addAll(c.additionalPackagesToScan()));
         return packagesToScan.toArray(String[]::new);
     }

--- a/fineract-provider/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/fineract-provider/src/main/resources/db/changelog/db.changelog-master.xml
@@ -34,6 +34,7 @@
     <!-- Add new module to the end of this modules list (to keep the existing auto-increment identifiers) -->
     <include file="db/changelog/tenant/module/loan/module-changelog-master.xml" context="tenant_db AND !initial_switch"/>
     <include file="db/changelog/tenant/module/investor/module-changelog-master.xml" context="tenant_db AND !initial_switch"/>
+    <include file="db/changelog/tenant/module/local/module-changelog-master.xml" context="tenant_db AND !initial_switch"/>
     <includeAll path="db/custom-changelog" errorIfMissingOrEmpty="false" context="tenant_db AND !initial_switch AND custom_changelog"/>
     <!-- Scripts to run after the modules were initialized  -->
     <include file="tenant/final-changelog-tenant.xml" relativeToChangelogFile="true" context="tenant_db AND !initial_switch"/>

--- a/fineract-provider/src/main/resources/jpa/persistence.xml
+++ b/fineract-provider/src/main/resources/jpa/persistence.xml
@@ -161,6 +161,9 @@
         <class>org.apache.fineract.portfolio.tax.domain.TaxComponentHistory</class>
         <class>org.apache.fineract.portfolio.tax.domain.TaxGroup</class>
         <class>org.apache.fineract.portfolio.tax.domain.TaxGroupMappings</class>
+
+        <!-- Belat module-->
+        <class>com.belat.fineract.portfolio.promissorynote.domain.PromissoryNote</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.weaving" value="static" />

--- a/fineract-savings/src/main/resources/jpa/savings/persistence.xml
+++ b/fineract-savings/src/main/resources/jpa/savings/persistence.xml
@@ -66,6 +66,9 @@
         <class>org.apache.fineract.portfolio.tax.domain.TaxGroupMappings</class>
         <class>org.apache.fineract.portfolio.tax.domain.TaxComponent</class>
         <class>org.apache.fineract.portfolio.tax.domain.TaxComponentHistory</class>
+
+        <!-- Belat module -->
+        <class>com.belat.fineract.portfolio.promissorynote.domain.PromissoryNote</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.weaving" value="static" />


### PR DESCRIPTION
## Description

Added functionality for the creation of promissory notes.
It is now possible to generate promissory notes with data associated with a savings transaction, when an investment is made.
This includes persistence in the database and exposure of a new API endpoint.

## Checklist

- [x] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [x] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [x] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

