### PR TITLE
Enhancement to send max allowed deposit limit parameter when create savings fund

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/SavingsApiConstants.java
+++ b/fineract-core/src/main/java/org/apache/fineract/portfolio/savings/SavingsApiConstants.java
@@ -114,6 +114,7 @@ public class SavingsApiConstants {
     public static final String interestCalculationTypeParamName = "interestCalculationType";
     public static final String interestCalculationDaysInYearTypeParamName = "interestCalculationDaysInYearType";
     public static final String minRequiredOpeningBalanceParamName = "minRequiredOpeningBalance";
+    public static final String maxAllowedDepositLimit = "maxAllowedDepositLimit";
     public static final String lockinPeriodFrequencyParamName = "lockinPeriodFrequency";
     public static final String lockinPeriodFrequencyTypeParamName = "lockinPeriodFrequencyType";
     public static final String withdrawalFeeAmountParamName = "withdrawalFeeAmount";

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/fund/LoanFundServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/fund/LoanFundServiceImpl.java
@@ -104,7 +104,7 @@ public class LoanFundServiceImpl {
     private JsonObject createSavingAccountData(final BigDecimal amount, final Long clientId, final String accountNo,
             final DateTimeFormatter formatter) {
         JsonObject accountJson = new JsonObject();
-        accountJson.addProperty("minRequiredOpeningBalance", amount);
+        accountJson.addProperty("maxAllowedDepositLimit", amount);
         accountJson.addProperty("dateFormat", DateUtils.DEFAULT_DATE_FORMAT);
         accountJson.addProperty("locale", Locale.ENGLISH.toString());
         accountJson.addProperty("submittedOnDate", DateUtils.getBusinessLocalDate().format(formatter));

--- a/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountConstant.java
+++ b/fineract-savings/src/main/java/org/apache/fineract/portfolio/savings/data/SavingsAccountConstant.java
@@ -39,7 +39,7 @@ public class SavingsAccountConstant extends SavingsApiConstants {
             withdrawalFeeForTransfersParamName, feeAmountParamName, feeOnMonthDayParamName, chargesParamName, allowOverdraftParamName,
             overdraftLimitParamName, minRequiredBalanceParamName, enforceMinRequiredBalanceParamName, lienAllowedParamName,
             maxAllowedLienLimitParamName, nominalAnnualInterestRateOverdraftParamName, minOverdraftForInterestCalculationParamName,
-            withHoldTaxParamName, datatables, gsimApplicationId, gsimLastApplication));
+            withHoldTaxParamName, datatables, gsimApplicationId, gsimLastApplication, maxAllowedDepositLimit));
 
     /**
      * These parameters will match the class level parameters of {@link SavingsAccountData}. Where possible, we try to


### PR DESCRIPTION
- Send maxAllowedDepositLimit paremeter when create savings fund 
- Support maxAllowedDepositLimit parameter in savings api constants to receive it when create a new savings account
